### PR TITLE
Allow caller to specify a delay time before livereload fires off

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,24 @@ The project uses [sasstools/sass-lint](https://github.com/sasstools/sass-lint) f
     
 You can also create your own lint file and modify the path.
 
+## Arguments
+
+#### `--production`
+
+Use the `--production` flag when executing `gulp`in order to generate the build files 
+that should be put on a production environment.
+
+#### `--livereload_delay`
+
+You can prevent livereload from firing off immediately after the css has been 
+compiled into the css folder. This might be useful for certain environments where
+there can be a minor delay between the files getting generated, and the Drupal build
+detecting them (e.g: docker for mac).
+
+The delay time is specified in milliseconds (ms).
+
+##### Example usage:
+
+  `gulp watch --livereload_delay 1700`
+
+  Would wait 1,7 seconds before firing off the livereload update.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You can also create your own lint file and modify the path.
 Use the `--production` flag when executing `gulp`in order to generate the build files 
 that should be put on a production environment.
 
-#### `--livereload_delay`
+#### `--livereload-delay`
 
 You can prevent livereload from firing off immediately after the css has been 
 compiled into the css folder. This might be useful for certain environments where
@@ -72,6 +72,6 @@ The delay time is specified in milliseconds (ms).
 
 ##### Example usage:
 
-  `gulp watch --livereload_delay 1700`
+  `gulp watch --livereload-delay 1700`
 
   Would wait 1,7 seconds before firing off the livereload update.

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ var production = typeof argv.production !== 'undefined';
 
 // Allow to delay livereload execution so that it doesn't get triggered right
 // away after compiling sass files.
-var livereload_delay = (typeof argv.livereload_delay !== 'undefined') ? argv.livereload_delay : 0;
+var livereloadDelay = (typeof argv['livereload-delay'] !== 'undefined') ? argv['livereload-delay'] : 0;
 
 // Define paths in the filesystem for easy access.
 var paths = {
@@ -64,7 +64,7 @@ module.exports = function (gulp) {
       .pipe(gulpif(production, cleanCSS({compatibility: 'ie8'})))
       .pipe(gulpif(!production, sourceMaps.write()))
       .pipe(gulp.dest(paths.css))
-      .pipe(wait(livereload_delay))
+      .pipe(wait(livereloadDelay))
       .pipe(gulpif(!production, liveReload()));
   });
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,10 @@ var autoprefixer = require('gulp-autoprefixer'),
 // used in production.
 var production = typeof argv.production !== 'undefined';
 
+// Allow to delay livereload execution so that it doesn't get triggered right
+// away after compiling sass files.
+var livereload_delay = (typeof argv.livereload_delay !== 'undefined') ? argv.livereload_delay : 0;
+
 // Define paths in the filesystem for easy access.
 var paths = {
   'css': 'css',
@@ -59,8 +63,9 @@ module.exports = function (gulp) {
       .pipe(autoprefixer({ cascade: false }))
       .pipe(gulpif(production, cleanCSS({compatibility: 'ie8'})))
       .pipe(gulpif(!production, sourceMaps.write()))
-      .pipe(gulpif(!production, liveReload()))
-      .pipe(gulp.dest(paths.css));
+      .pipe(gulp.dest(paths.css))
+      .pipe(wait(livereload_delay))
+      .pipe(gulpif(!production, liveReload()));
   });
 
   /**


### PR DESCRIPTION
Changes from the BSPWEB gulpfile added here, by using an optional --livereload_delay flag.

Also documented that argument and the existing "--production" one in the README file